### PR TITLE
Try to fix issue with hideplayers

### DIFF
--- a/src/main/java/hu/montlikadani/tablist/bukkit/listeners/Listeners.java
+++ b/src/main/java/hu/montlikadani/tablist/bukkit/listeners/Listeners.java
@@ -8,10 +8,13 @@ import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import hu.montlikadani.tablist.bukkit.ConfigValues;
+import hu.montlikadani.tablist.bukkit.HidePlayers;
 import hu.montlikadani.tablist.bukkit.TabList;
+import hu.montlikadani.tablist.bukkit.utils.ServerVersion.Version;
 import hu.montlikadani.tablist.bukkit.utils.UpdateDownloader;
 
 public class Listeners implements Listener {
@@ -49,6 +52,37 @@ public class Listeners implements Listener {
 			} else {
 				plugin.getHidePlayers().get(p).removePlayerFromTab(p, p);
 			}
+		}
+	}
+
+	@EventHandler
+	public void onPlayerMove(PlayerMoveEvent event) {
+		if (Version.isCurrentLower(Version.v1_13_R2) || event.getTo() == null)
+			return;
+
+		Player player = event.getPlayer();
+		if (!plugin.getHidePlayers().containsKey(player)) {
+			return;
+		}
+
+		// int clientViewDistance = player.getClientViewDistance();
+		int bukkitViewDistance = org.bukkit.Bukkit.getViewDistance();
+		int distance = (int) ((event.getFrom().getX() + event.getTo().getX()) - bukkitViewDistance);
+
+		if (distance > bukkitViewDistance) {
+			player.getWorld()
+					.getNearbyEntities(player.getLocation(), bukkitViewDistance, bukkitViewDistance, bukkitViewDistance)
+					.stream().filter(e -> e instanceof Player).forEach(e -> {
+						HidePlayers hp = plugin.getHidePlayers().get(player);
+						hp.addPlayerToTab((Player) e);
+					});
+		} else {
+			player.getWorld()
+					.getNearbyEntities(player.getLocation(), bukkitViewDistance, bukkitViewDistance, bukkitViewDistance)
+					.stream().filter(e -> e instanceof Player).forEach(e -> {
+						HidePlayers hp = plugin.getHidePlayers().get(player);
+						hp.removePlayerFromTab(player, (Player) e);
+					});
 		}
 	}
 


### PR DESCRIPTION
Fixes #147 

After hiding from the player list, when a player leaves the `view-distance` option specified in the `server.properties` file to any appropriate value, the player disappears after that distance and is not visible on the ground. It is not visible even if it is moving within sight.

This can reproduce in all mc versions.

EDIT: distance apis is added in 1.14
Another catch: We can try to add player before removing. [#post](https://www.spigotmc.org/threads/issue-hide-player-in-playerlist-only.452865/#post-3885144)