### PR TITLE
Implement tablist entries

### DIFF
--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/config/Configuration.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/config/Configuration.java
@@ -11,14 +11,15 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import hu.montlikadani.tablist.bukkit.TabList;
 import hu.montlikadani.tablist.bukkit.config.constantsLoader.ConfigValues;
 import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabConfigValues;
+import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabEntryValues;
 
 public class Configuration {
 
 	private TabList plugin;
 
 	private FileConfiguration messages, groups, fakePlayers, animCreator;
-	private CommentedConfig config, tablist;
-	private File configFile, messagesFile, animationFile, tablistFile, groupsFile, fakePlayersFile;
+	private CommentedConfig config, tablist, tabEntries;
+	private File configFile, messagesFile, animationFile, tablistFile, groupsFile, fakePlayersFile, tabEntriesFile;
 
 	public Configuration(TabList plugin) {
 		this.plugin = plugin;
@@ -31,6 +32,7 @@ public class Configuration {
 		tablistFile = new File(folder, "tablist.yml");
 		groupsFile = new File(folder, "groups.yml");
 		fakePlayersFile = new File(folder, "fakeplayers.yml");
+		tabEntriesFile = new File(folder, "tabentries.yml");
 	}
 
 	public void loadFiles() {
@@ -54,6 +56,14 @@ public class Configuration {
 		tablist = new CommentedConfig(tablistFile);
 		tablist.load();
 		TabConfigValues.loadValues(tablist);
+
+		if (!tabEntriesFile.exists()) {
+			plugin.saveResource("tabentries.yml", false);
+		}
+
+		tabEntries = new CommentedConfig(tabEntriesFile);
+		tabEntries.load();
+		TabEntryValues.loadValues(tabEntries);
 
 		try {
 			messages = createFile(messagesFile, "messages.yml", false);
@@ -131,6 +141,10 @@ public class Configuration {
 		return tablist;
 	}
 
+	public CommentedConfig getTabEntries() {
+		return tabEntries;
+	}
+
 	public File getConfigFile() {
 		return configFile;
 	}
@@ -153,5 +167,9 @@ public class Configuration {
 
 	public File getFakeplayersFile() {
 		return fakePlayersFile;
+	}
+
+	public File getTabEntriesFile() {
+		return tabEntriesFile;
 	}
 }

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/config/constantsLoader/TabEntryValues.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/config/constantsLoader/TabEntryValues.java
@@ -1,0 +1,255 @@
+package hu.montlikadani.tablist.bukkit.config.constantsLoader;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import hu.montlikadani.tablist.bukkit.config.CommentedConfig;
+import hu.montlikadani.tablist.bukkit.utils.Util;
+
+public final class TabEntryValues {
+
+	private static boolean enabled = false;
+
+	private static int columns;
+	private static long refreshRate;
+
+	public static final Map<ColumnValues.ConfigType, List<ColumnValues>> COLUMN_SECTION = new HashMap<>();
+	public static final Map<PlaceholderSetting.SettingType, PlaceholderSetting> VARIABLE_SETTINGS = new HashMap<>();
+
+	public static void loadValues(CommentedConfig c) {
+		if (!(enabled = c.getBoolean("enabled", false))) {
+			return;
+		}
+
+		columns = c.getInt("columns-size", 4);
+		if (columns > 4 || columns < 1) {
+			columns = 4;
+		}
+
+		refreshRate = c.getLong("refresh-rate", 6L);
+		if (refreshRate < 1) {
+			refreshRate = 6L;
+		}
+
+		for (PlaceholderSetting.SettingType type : PlaceholderSetting.SettingType.values()) {
+			String path = "placeholder-setting." + type.name + ".";
+
+			int max = c.getInt(path + "max", 8);
+			if (max >= 20) {
+				max = 19;
+			}
+
+			Set<PlaceholderSetting.EntryCondition> conditions = new HashSet<>();
+			for (String condition : c.getStringList(path + "conditions")) {
+				if (condition.replace("!", "").isEmpty()) {
+					continue;
+				}
+
+				if (condition.startsWith("!")) {
+					conditions.add(new PlaceholderSetting.EntryCondition(
+							PlaceholderSetting.EntryCondition.ConditionType.getByName(condition.substring(1)), false));
+				} else {
+					conditions.add(new PlaceholderSetting.EntryCondition(
+							PlaceholderSetting.EntryCondition.ConditionType.getByName(condition), true));
+				}
+			}
+
+			VARIABLE_SETTINGS.put(type, new PlaceholderSetting(max, conditions));
+		}
+
+		for (ColumnValues.ConfigType type : ColumnValues.ConfigType.values()) {
+			List<ColumnValues> columnValues = new ArrayList<>();
+
+			if (type == ColumnValues.ConfigType.DEFAULT) {
+				String text = c.getString(type.path + "text", " ");
+				UUID head = Util.tryParseId(c.getString(type.path + "head"))
+						.orElse(UUID.fromString("7f2fa3f7-b400-4c08-b816-65d2de5d9010"));
+				int ping = Util.tryParse(c.getString(type.path + "ping", "1000")).orElse(1000);
+
+				columnValues.add(new ColumnValues(text, head, ping, 0));
+			} else if (type == ColumnValues.ConfigType.NORMAL) {
+				ConfigurationSection section = c.getConfigurationSection(type.path);
+				if (section != null) {
+					for (String col : section.getKeys(false)) {
+						int column = Util.tryParse(col).orElse(0);
+						if (column <= 0 || column > 4) {
+							continue;
+						}
+
+						for (String rowContext : section.getStringList(col)) {
+							String text = "";
+							UUID headId = null;
+							int ping = 1000;
+
+							String[] split = rowContext.split(";");
+							if (split.length == 0) {
+								if (rowContext.contains("ping:")) {
+									ping = Util.tryParse(rowContext.replace("ping:", "")).orElse(1000);
+								} else if (rowContext.contains("head:")) {
+									headId = Util.tryParseId(rowContext.replace("head:", "")).orElse(null);
+								} else {
+									text = rowContext;
+								}
+							} else {
+								for (String one : split) {
+									if (one.contains("ping:")) {
+										ping = Util.tryParse(one.replace("ping:", "")).orElse(1000);
+									} else if (one.contains("head:")) {
+										headId = Util.tryParseId(one.replace("head:", "")).orElse(null);
+									} else {
+										text = one;
+									}
+								}
+							}
+
+							columnValues.add(new ColumnValues(text, headId, ping, column));
+						}
+					}
+				}
+			}
+
+			COLUMN_SECTION.put(type, columnValues);
+		}
+	}
+
+	public static final class ColumnValues {
+
+		private UUID headId;
+		private String text;
+		private int ping, column;
+
+		private ColumnValues(String text, UUID headId, int ping, int column) {
+			this.text = text;
+			this.headId = headId;
+			this.ping = ping;
+			this.column = column;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public UUID getHeadId() {
+			return headId;
+		}
+
+		public int getPing() {
+			return ping;
+		}
+
+		public int getColumn() {
+			return column;
+		}
+
+		public enum ConfigType {
+			DEFAULT("default."), NORMAL("columns");
+
+			public final String path;
+
+			ConfigType(String path) {
+				this.path = path;
+			}
+		}
+	}
+
+	public static final class PlaceholderSetting {
+
+		private int max;
+
+		private final Set<EntryCondition> conditions = new HashSet<>();
+
+		private PlaceholderSetting(int max, Set<EntryCondition> conditions) {
+			this.max = max;
+			this.conditions.addAll(conditions);
+		}
+
+		public int getMax() {
+			return max;
+		}
+
+		public Set<EntryCondition> getConditions() {
+			return conditions;
+		}
+
+		public Boolean parseCondition(EntryCondition.ConditionType type) {
+			for (EntryCondition condition : conditions) {
+				if (condition.type == type) {
+					return condition.value;
+				}
+			}
+
+			return null;
+		}
+
+		// 2nd inner class, why I'm doing this, idk
+		public static final class EntryCondition {
+
+			private ConditionType type;
+			private boolean value;
+
+			public EntryCondition(ConditionType type, boolean value) {
+				this.type = type;
+				this.value = value;
+			}
+
+			public ConditionType getType() {
+				return type;
+			}
+
+			public boolean getValue() {
+				return value;
+			}
+
+			// TODO add more conditions
+			public enum ConditionType {
+				IS_AFK, IS_VANISHED;
+
+				private String name = super.toString().replace("_", "").toLowerCase();
+
+				@Override
+				public String toString() {
+					return name;
+				}
+
+				public static ConditionType getByName(String name) {
+					for (ConditionType type : values()) {
+						if (type.name.equalsIgnoreCase(name)) {
+							return type;
+						}
+					}
+
+					return null;
+				}
+			}
+		}
+
+		public enum SettingType {
+			WORLD_PLAYERS("world_players"), ONLINE_PLAYERS("players"), PLAYERS_IN_GROUP("players_in_group");
+
+			public final String name;
+
+			SettingType(String name) {
+				this.name = name;
+			}
+		}
+	}
+
+	public static boolean isEnabled() {
+		return enabled;
+	}
+
+	public static int getColumns() {
+		return columns;
+	}
+
+	public static long getRefreshRate() {
+		return refreshRate;
+	}
+}

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/listeners/plugins/AfkPlayers.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/listeners/plugins/AfkPlayers.java
@@ -15,6 +15,7 @@ import org.bukkit.scoreboard.Team;
 import hu.montlikadani.tablist.bukkit.TabList;
 import hu.montlikadani.tablist.bukkit.API.TabListAPI;
 import hu.montlikadani.tablist.bukkit.config.constantsLoader.ConfigValues;
+import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabEntryValues;
 
 public abstract class AfkPlayers {
 
@@ -23,6 +24,10 @@ public abstract class AfkPlayers {
 	private final TabList plugin = TabListAPI.getPlugin();
 
 	protected void goAfk(Player player, boolean value) {
+		if (TabEntryValues.isEnabled()) {
+			plugin.getUser(player).ifPresent(user -> plugin.getTabManager().getTabEntries().beginUpdate(user));
+		}
+
 		if (ConfigValues.isAfkStatusEnabled() && !ConfigValues.isAfkStatusShowPlayerGroup()) {
 			String path = "placeholder-format.afk-status.format-" + (value ? "yes" : "no");
 			String result = "";

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/TabManager.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/TabManager.java
@@ -12,6 +12,7 @@ import org.bukkit.scheduler.BukkitTask;
 
 import hu.montlikadani.tablist.bukkit.TabList;
 import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabConfigValues;
+import hu.montlikadani.tablist.bukkit.tablist.entry.TabEntries;
 import hu.montlikadani.tablist.bukkit.user.TabListUser;
 import hu.montlikadani.tablist.bukkit.utils.task.Tasks;
 
@@ -22,8 +23,11 @@ public class TabManager {
 	private TabList plugin;
 	private BukkitTask task;
 
+	private final TabEntries tabEntries;
+
 	public TabManager(TabList plugin) {
 		this.plugin = plugin;
+		tabEntries = new TabEntries(plugin);
 	}
 
 	public BukkitTask getTask() {
@@ -37,7 +41,13 @@ public class TabManager {
 		}
 	}
 
+	public TabEntries getTabEntries() {
+		return tabEntries;
+	}
+
 	public void addPlayer(TabListUser user) {
+		tabEntries.beginUpdate(user);
+
 		if (!TabConfigValues.isEnabled()) {
 			return;
 		}
@@ -66,6 +76,7 @@ public class TabManager {
 
 	public void removePlayer(TabListUser user) {
 		TabTitle.sendTabTitle(user.getPlayer(), "", "");
+		tabEntries.removePlayer(user.getUniqueId());
 	}
 
 	public void removeAll() {
@@ -74,6 +85,8 @@ public class TabManager {
 		for (TabListUser user : plugin.getUsers()) {
 			TabTitle.sendTabTitle(user.getPlayer(), "", "");
 		}
+
+		tabEntries.removeAll();
 	}
 
 	public void loadToggledTabs() {

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/TabEntries.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/TabEntries.java
@@ -242,7 +242,6 @@ public final class TabEntries {
 		protected static final class EntryBuilder {
 
 			private Entry entry;
-
 			private UUID headId;
 			private String text = " ";
 			private int ping = 0;

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/TabEntries.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/TabEntries.java
@@ -1,0 +1,288 @@
+package hu.montlikadani.tablist.bukkit.tablist.entry;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
+
+import hu.montlikadani.tablist.bukkit.TabList;
+import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabEntryValues;
+import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabEntryValues.ColumnValues;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.IRowPlayer;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.InfoName;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.RowPlayer;
+import hu.montlikadani.tablist.bukkit.user.TabListUser;
+import hu.montlikadani.tablist.bukkit.utils.task.Tasks;
+
+public final class TabEntries {
+
+	private TabList plugin;
+	private Entry[][] entries;
+
+	private BukkitTask task;
+
+	public TabEntries(TabList plugin) {
+		this.plugin = plugin;
+	}
+
+	public Entry[][] getEntries() {
+		return Arrays.copyOf(entries, entries.length);
+	}
+
+	public BukkitTask getTask() {
+		return task;
+	}
+
+	public void cancelTask() {
+		if (task != null) {
+			task.cancel();
+			task = null;
+		}
+	}
+
+	public Optional<Entry> getEntry(Predicate<Entry> condition) {
+		if (entries == null || condition == null) {
+			return Optional.empty();
+		}
+
+		for (int column = 0; column < entries.length; column++) {
+			for (int row = 0; row < 20; row++) {
+				Entry entry = entries[column][row];
+				if (entry != null && condition.test(entry)) {
+					return Optional.of(entry);
+				}
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	public void beginUpdate(TabListUser user) {
+		if (!TabEntryValues.isEnabled()) {
+			return;
+		}
+
+		final Player player = user.getPlayer();
+
+		InfoName.removePlayer(plugin, player);
+		appendEntries();
+
+		if (task == null) {
+			// #removeAll method loop too slow so we gives delay a bit when reloading
+			try {
+				Thread.sleep(500);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+
+			createRows();
+
+			task = Tasks.submitAsync(() -> {
+				if (plugin.getUsers().isEmpty()) {
+					removeAll();
+					return;
+				}
+
+				updateEntries();
+			}, 4L, TabEntryValues.getRefreshRate());
+		} else {
+			loopEntries(entry -> {
+				RowPlayer row = (RowPlayer) entry.row;
+				row.show(player); // Show the rows to the player
+				row.replacer.requestUpdate(); // Request to update existing entry variables
+			});
+		}
+	}
+
+	public void removePlayer(UUID uuid) {
+		getEntry(entry -> {
+			Optional<Player> opt = entry.row.asPlayer();
+			return opt.isPresent() && opt.get().getUniqueId().equals(uuid);
+		}).ifPresent(entry -> {
+			IRowPlayer row = entry.row;
+
+			row.remove();
+			row.setPlayer(null);
+
+			// Only do a request if there is at least 2 players
+			if (plugin.getUsers().size() > 1) {
+				((RowPlayer) row).replacer.requestUpdate();
+			}
+		});
+	}
+
+	public void removeAll() {
+		cancelTask();
+		loopEntries(entry -> entry.row.remove());
+
+		// Restore all player
+		for (TabListUser user : plugin.getUsers()) {
+			InfoName.addPlayer(plugin, user.getPlayer());
+		}
+
+		entries = null;
+	}
+
+	public void updateEntries() {
+		loopEntries(entry -> {
+			for (TabListUser user : plugin.getUsers()) {
+				entry.row.updateText(user.getPlayer(), entry.row.getText());
+			}
+		});
+	}
+
+	public void fillWithDefault() {
+		for (int column = 0; column < entries.length; column++) {
+			for (int row = 0; row < 20; row++) {
+				if (entries[column][row] != null) {
+					continue;
+				}
+
+				Entry.EntryBuilder builder = Entry.of();
+
+				Optional.ofNullable(TabEntryValues.COLUMN_SECTION.get(TabEntryValues.ColumnValues.ConfigType.DEFAULT))
+						.filter(list -> !list.isEmpty()).ifPresent(list -> {
+							ColumnValues value = list.get(0);
+							builder.setPing(value.getPing()).setHeadId(value.getHeadId()).setText(value.getText());
+						});
+
+				entries[column][row] = builder.build(this);
+			}
+		}
+	}
+
+	private void createRows() {
+		if (entries != null) {
+			int rowIndex = 0;
+
+			for (int column = 0; column < entries.length; column++) {
+				for (int row = 0; row < 20; row++) {
+					Entry entry = entries[column][row];
+					if (entry != null) {
+						entry.row.create(rowIndex);
+						((RowPlayer) entry.row).columnIndex = column;
+						rowIndex++;
+					}
+				}
+			}
+		}
+	}
+
+	private void appendEntries() {
+		// Only fill array with values if null or the array length is not equal to
+		// columns count
+		if (entries != null || (entries != null && entries.length == TabEntryValues.getColumns())) {
+			return;
+		}
+
+		cancelTask();
+
+		entries = new Entry[TabEntryValues.getColumns()][20];
+
+		Optional.ofNullable(TabEntryValues.COLUMN_SECTION.get(TabEntryValues.ColumnValues.ConfigType.NORMAL))
+				.ifPresent(list -> {
+					int rowIndex = 0, column = 0;
+
+					for (ColumnValues value : list) {
+						Entry.EntryBuilder builder = Entry.of().setHeadId(value.getHeadId()).setPing(value.getPing())
+								.setText(value.getText());
+
+						if (column != value.getColumn()) {
+							rowIndex = 0;
+						}
+
+						if ((column = value.getColumn()) > entries.length) {
+							continue;
+						}
+
+						entries[column - 1][rowIndex] = builder.build(this);
+						rowIndex++;
+					}
+				});
+
+		fillWithDefault();
+	}
+
+	private void loopEntries(Consumer<Entry> consumer) {
+		if (entries != null) {
+			for (int column = 0; column < entries.length; column++) {
+				for (int row = 0; row < 20; row++) {
+					Entry entry = entries[column][row];
+					if (entry != null) {
+						consumer.accept(entry);
+					}
+				}
+			}
+		}
+	}
+
+	public static final class Entry {
+
+		private IRowPlayer row;
+
+		private Entry() {
+		}
+
+		public IRowPlayer getRow() {
+			return row;
+		}
+
+		public static EntryBuilder of() {
+			return new EntryBuilder();
+		}
+
+		public EntryBuilder toBuilder() {
+			return new EntryBuilder(this);
+		}
+
+		protected static final class EntryBuilder {
+
+			private Entry entry;
+
+			private UUID headId;
+			private String text = " ";
+			private int ping = 0;
+
+			private EntryBuilder() {
+			}
+
+			private EntryBuilder(Entry entry) {
+				this.entry = entry;
+			}
+
+			public EntryBuilder setText(String text) {
+				this.text = text;
+				return this;
+			}
+
+			public EntryBuilder setHeadId(UUID headId) {
+				this.headId = headId;
+				return this;
+			}
+
+			public EntryBuilder setPing(int ping) {
+				this.ping = ping;
+				return this;
+			}
+
+			protected Entry build(TabEntries root) {
+				if (entry == null) {
+					entry = new Entry();
+				}
+
+				IRowPlayer row = entry.row == null ? new RowPlayer(root) : entry.row;
+
+				row.setText(text);
+				row.setPing(ping);
+				row.setSkin(headId);
+
+				entry.row = row;
+				return entry;
+			}
+		}
+	}
+}

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/IRowPlayer.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/IRowPlayer.java
@@ -1,0 +1,82 @@
+package hu.montlikadani.tablist.bukkit.tablist.entry.row;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.bukkit.entity.Player;
+
+/**
+ * The interface for creating rows for tablist
+ */
+public interface IRowPlayer {
+
+	/**
+	 * Attempts to create this player to the given column and row index.
+	 * 
+	 * @param rowIndex the index of row where to set
+	 */
+	void create(int rowIndex);
+
+	/**
+	 * Attempts to remove this player from the given column and row index.
+	 */
+	void remove();
+
+	/**
+	 * @return the {@link Player} of this column if present
+	 */
+	Optional<Player> asPlayer();
+
+	/**
+	 * @return the text of this row
+	 */
+	String getText();
+
+	/**
+	 * Returns the current set of ping latency of this column.
+	 * 
+	 * @return the amount of latency
+	 */
+	int getPingLatency();
+
+	/**
+	 * Returns the current set of head id.
+	 * 
+	 * @return head id
+	 */
+	UUID getHeadId();
+
+	/**
+	 * Sets the given player to this row.
+	 * 
+	 * @param player {@link Player}
+	 */
+	void setPlayer(Player player);
+
+	/**
+	 * @param text the new text of this row
+	 */
+	void setText(String text);
+
+	/**
+	 * @param player {@link Player} where to update
+	 * @param text updates the text without modifying {@link #getText()}
+	 * @return the updated text
+	 */
+	String updateText(Player player, String text);
+
+	/**
+	 * Attempts to set this column ping to a new one.
+	 * 
+	 * @param ping value of this row (> 0)
+	 */
+	void setPing(int ping);
+
+	/**
+	 * Attempts to set the valid user skin uuid to player list for this column
+	 * before their name.
+	 * 
+	 * @param skinId a valid user skin uuid
+	 */
+	void setSkin(UUID skinId);
+}

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/InfoName.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/InfoName.java
@@ -1,0 +1,375 @@
+package hu.montlikadani.tablist.bukkit.tablist.entry.row;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+
+import hu.montlikadani.tablist.bukkit.TabList;
+import hu.montlikadani.tablist.bukkit.user.TabListUser;
+import hu.montlikadani.tablist.bukkit.utils.ServerVersion;
+import hu.montlikadani.tablist.bukkit.utils.reflection.NMSContainer;
+import hu.montlikadani.tablist.bukkit.utils.reflection.ReflectionUtils;
+
+@SuppressWarnings("unchecked")
+public final class InfoName {
+
+	private TabList plugin;
+	private int ping;
+
+	private String currentPlayerInfoAction;
+	private Object packet, rowPlayer, entityPlayer;
+	private GameProfile gameProfile;
+
+	private final Constructor<?> playOutPlayerInfoConstr = NMSContainer.getPlayOutPlayerInfoConstructor(),
+			playerInfoDataConstr = NMSContainer.getPlayerInfoDataConstructor();
+	private final Field infoList = NMSContainer.getInfoList();
+
+	public InfoName(TabList plugin) {
+		this.plugin = plugin;
+	}
+
+	public int getPing() {
+		return ping;
+	}
+
+	public void setPing(int ping) {
+		this.ping = ping >= -1 ? ping : 20;
+	}
+
+	public String getCurrentPlayerInfoAction() {
+		return currentPlayerInfoAction;
+	}
+
+	public Object getPacket() {
+		return packet;
+	}
+
+	public Object getRowPlayer() {
+		return rowPlayer;
+	}
+
+	public Object getEntityPlayer() {
+		return entityPlayer;
+	}
+
+	public GameProfile getGameProfile() {
+		return gameProfile;
+	}
+
+	public void addPlayer(Player player, String text, Player forWho) {
+		currentPlayerInfoAction = "ADD_PLAYER";
+
+		try {
+			if (player != null && entityPlayer != null) {
+				Object entityPlayerArray = Array.newInstance(entityPlayer.getClass(), 1);
+				Array.set(entityPlayerArray, 0, entityPlayer);
+
+				packet = playOutPlayerInfoConstr.newInstance(NMSContainer.getAddPlayer(), entityPlayerArray);
+			} else {
+				packet = playOutPlayerInfoConstr.newInstance(NMSContainer.getAddPlayer(),
+						Array.newInstance(NMSContainer.getEntityPlayerClass(), 0));
+			}
+
+			((List<Object>) infoList.get(packet)).add(rowPlayer = newPlayerInfoData(text));
+
+			if (forWho != null) {
+				ReflectionUtils.sendPacket(forWho, packet);
+				ReflectionUtils.sendPacket(forWho, rowPlayer);
+			} else {
+				sendPacketForEveryone();
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void create(String name, UUID skinId, String text) {
+		if (rowPlayer != null) {
+			return;
+		}
+
+		if (gameProfile == null) {
+			if (name.length() > 16) {
+				name = name.substring(0, 16);
+			}
+
+			gameProfile = new GameProfile(UUID.nameUUIDFromBytes(name.getBytes()), name);
+		}
+
+		CompletableFuture<Void> comp = new CompletableFuture<>();
+		if (ServerVersion.isCurrentEqualOrHigher(ServerVersion.v1_8_R2) && Bukkit.getServer().getOnlineMode()
+				&& skinId != null) {
+			comp = ReflectionUtils.getJsonComponent().getSkinValue(skinId.toString()).thenAcceptAsync(map -> {
+				java.util.Map.Entry<String, String> first = map.pollFirstEntry();
+				gameProfile.getProperties().get("textures").clear();
+				gameProfile.getProperties().put("textures", new Property("textures", first.getKey(), first.getValue()));
+			});
+		} else {
+			comp.complete(null);
+		}
+
+		comp.thenAccept(v -> {
+			addPlayer(null, text, null);
+			updateDisplayName(null, text, null);
+		});
+	}
+
+	public void movePlayer(Player player, int rowIndex) {
+		remove(player);
+
+		try {
+			String name = String.format("%03d", rowIndex);
+			if (name.length() > 16) {
+				name = name.substring(0, 16);
+			}
+
+			gameProfile = new GameProfile(UUID.nameUUIDFromBytes(name.getBytes()), name);
+			entityPlayer = ReflectionUtils.getHandle(player);
+
+			GameProfile currentProfile = (GameProfile) ReflectionUtils.invokeMethod(entityPlayer, "getProfile", true,
+					true);
+
+			gameProfile.getProperties().clear();
+			gameProfile.getProperties().putAll(currentProfile.getProperties());
+
+			Field profile = null;
+			for (Field gp : entityPlayer.getClass().getSuperclass().getDeclaredFields()) {
+				if (gp.getType().equals(currentProfile.getClass())) {
+					profile = gp;
+					ReflectionUtils.modifyFinalField(gp, entityPlayer, gameProfile);
+					break;
+				}
+			}
+
+			if (profile == null) {
+				return;
+			}
+
+			profile.setAccessible(true);
+
+			gameProfile = (GameProfile) profile.get(entityPlayer);
+
+			addPlayer(player, player.getName(), null);
+
+			ReflectionUtils.modifyFinalField(profile, entityPlayer, currentProfile);
+			currentProfile = (GameProfile) ReflectionUtils.invokeMethod(entityPlayer, "getProfile", true, true);
+
+			Object entityPlayerArray = Array.newInstance(entityPlayer.getClass(), 1);
+			Array.set(entityPlayerArray, 0, entityPlayer);
+
+			Object packet = playOutPlayerInfoConstr.newInstance(NMSContainer.getUpdateDisplayName(), entityPlayerArray);
+
+			Object rowPlayer;
+			if (playerInfoDataConstr.getParameterCount() == 5) {
+				rowPlayer = playerInfoDataConstr.newInstance(packet, currentProfile, ping, NMSContainer.getGameMode(),
+						ReflectionUtils.getAsIChatBaseComponent(player.getName()));
+			} else {
+				rowPlayer = playerInfoDataConstr.newInstance(currentProfile, ping, NMSContainer.getGameMode(),
+						ReflectionUtils.getAsIChatBaseComponent(player.getName()));
+			}
+
+			infoList.set(packet, Arrays.asList(rowPlayer));
+
+			final Object rp = rowPlayer;
+
+			// Need some tick delay to show player
+			Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, () -> {
+				for (TabListUser user : plugin.getUsers()) {
+					Player pl = user.getPlayer();
+
+					ReflectionUtils.sendPacket(pl, packet);
+					ReflectionUtils.sendPacket(pl, rp);
+				}
+			}, 5L);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void remove(Player player) {
+		try {
+			currentPlayerInfoAction = "REMOVE_PLAYER";
+
+			packet = playOutPlayerInfoConstr.newInstance(NMSContainer.getRemovePlayer(),
+					Array.newInstance(NMSContainer.getEntityPlayerClass(), 0));
+
+			infoList.set(packet, Arrays.asList(rowPlayer = newPlayerInfoData("")));
+
+			sendPacketForEveryone();
+
+			if (player != null) {
+				entityPlayer = ReflectionUtils.getHandle(player);
+
+				Object entityPlayerArray = Array.newInstance(entityPlayer.getClass(), 1);
+				Array.set(entityPlayerArray, 0, entityPlayer);
+
+				currentPlayerInfoAction = "REMOVE_PLAYER";
+
+				packet = playOutPlayerInfoConstr.newInstance(NMSContainer.getRemovePlayer(), entityPlayerArray);
+
+				for (TabListUser user : plugin.getUsers()) {
+					ReflectionUtils.sendPacket(user.getPlayer(), packet);
+				}
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void updateDisplayName(TabListUser user, String name, Player forWho) {
+		if (user != null) {
+			for (TabListUser u : plugin.getUsers()) {
+				try {
+					Player player = u.getPlayer();
+
+					if (u.equals(user) && !"UPDATE_DISPLAY_NAME".equals(currentPlayerInfoAction)) {
+						if (entityPlayer == null) {
+							entityPlayer = ReflectionUtils.getHandle(player);
+						}
+
+						Object entityPlayerArray = Array.newInstance(entityPlayer.getClass(), 1);
+						Array.set(entityPlayerArray, 0, entityPlayer);
+
+						currentPlayerInfoAction = "UPDATE_DISPLAY_NAME";
+
+						packet = NMSContainer.getPacketPlayOutPlayerInfo()
+								.getConstructor(NMSContainer.getEnumPlayerInfoAction(), entityPlayerArray.getClass())
+								.newInstance(NMSContainer.getUpdateDisplayName(), entityPlayerArray);
+					}
+
+					// ((List<Object>) infoList.get(packet)).add(rowPlayer = newPlayerInfoData(name));
+					infoList.set(packet, Arrays.asList(rowPlayer = newPlayerInfoData(name)));
+
+					ReflectionUtils.sendPacket(player, packet);
+					ReflectionUtils.sendPacket(player, rowPlayer);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		} else {
+			try {
+				// Send a new packet for empty rows
+				if (!"UPDATE_DISPLAY_NAME".equals(currentPlayerInfoAction)) {
+					currentPlayerInfoAction = "UPDATE_DISPLAY_NAME";
+
+					packet = playOutPlayerInfoConstr.newInstance(NMSContainer.getUpdateDisplayName(),
+							Array.newInstance(NMSContainer.getEntityPlayerClass(), 0));
+				}/* else {
+					ReflectionUtils.modifyFinalField(ReflectionUtils.getField(rowPlayer, "e"), rowPlayer,
+					ReflectionUtils.getAsIChatBaseComponent(name));
+				}*/
+
+				infoList.set(packet, Arrays.asList(rowPlayer = newPlayerInfoData(name)));
+
+				if (forWho != null) {
+					ReflectionUtils.sendPacket(forWho, packet);
+					ReflectionUtils.sendPacket(forWho, rowPlayer);
+				} else {
+					sendPacketForEveryone();
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	public void setSkin(String text, UUID skinId) {
+		ReflectionUtils.getJsonComponent().getSkinValue(skinId.toString()).thenAcceptAsync(map -> {
+			java.util.Map.Entry<String, String> first = map.pollFirstEntry();
+			gameProfile.getProperties().get("textures").clear();
+			gameProfile.getProperties().put("textures", new Property("textures", first.getKey(), first.getValue()));
+
+			try {
+				currentPlayerInfoAction = "UPDATE_DISPLAY_NAME";
+
+				packet = playOutPlayerInfoConstr.newInstance(NMSContainer.getUpdateDisplayName(),
+						Array.newInstance(NMSContainer.getEntityPlayerClass(), 0));
+
+				infoList.set(packet, Arrays.asList(rowPlayer = newPlayerInfoData(text)));
+
+				sendPacketForEveryone();
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		});
+	}
+
+	public void sendPacketForEveryone() {
+		for (TabListUser user : plugin.getUsers()) {
+			Player player = user.getPlayer();
+
+			ReflectionUtils.sendPacket(player, packet);
+			ReflectionUtils.sendPacket(player, rowPlayer);
+		}
+	}
+
+	private Object newPlayerInfoData(String text) throws Exception {
+		if (playerInfoDataConstr.getParameterCount() == 5) {
+			return playerInfoDataConstr.newInstance(packet, gameProfile, ping, NMSContainer.getGameMode(),
+					ReflectionUtils.getAsIChatBaseComponent(text));
+		}
+
+		return playerInfoDataConstr.newInstance(gameProfile, ping, NMSContainer.getGameMode(),
+				ReflectionUtils.getAsIChatBaseComponent(text));
+	}
+
+	public static void removePlayer(final TabList plugin, Player player) {
+		if (player == null) {
+			return;
+		}
+
+		try {
+			Object entityPlayer = ReflectionUtils.getHandle(player);
+
+			Object entityPlayerArray = Array.newInstance(entityPlayer.getClass(), 1);
+			Array.set(entityPlayerArray, 0, entityPlayer);
+
+			Object packet = NMSContainer.getPacketPlayOutPlayerInfo()
+					.getConstructor(NMSContainer.getEnumPlayerInfoAction(), entityPlayerArray.getClass())
+					.newInstance(NMSContainer.getRemovePlayer(), entityPlayerArray);
+
+			Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, () -> {
+				for (TabListUser user : plugin.getUsers()) {
+					ReflectionUtils.sendPacket(user.getPlayer(), packet);
+				}
+			}, 20L); // 1 second to remove? lmao
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	public static void addPlayer(final TabList plugin, Player player) {
+		if (player == null) {
+			return;
+		}
+
+		try {
+			Object entityPlayer = ReflectionUtils.getHandle(player);
+
+			Object entityPlayerArray = Array.newInstance(entityPlayer.getClass(), 1);
+			Array.set(entityPlayerArray, 0, entityPlayer);
+
+			Object packet = NMSContainer.getPacketPlayOutPlayerInfo()
+					.getConstructor(NMSContainer.getEnumPlayerInfoAction(), entityPlayerArray.getClass())
+					.newInstance(NMSContainer.getAddPlayer(), entityPlayerArray);
+
+			Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, () -> {
+				for (TabListUser user : plugin.getUsers()) {
+					ReflectionUtils.sendPacket(user.getPlayer(), packet);
+				}
+			}, 5L);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/RowPlayer.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/RowPlayer.java
@@ -1,0 +1,157 @@
+package hu.montlikadani.tablist.bukkit.tablist.entry.row;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import hu.montlikadani.tablist.bukkit.TabList;
+import hu.montlikadani.tablist.bukkit.API.TabListAPI;
+import hu.montlikadani.tablist.bukkit.tablist.entry.TabEntries;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.VariableReplacer;
+import hu.montlikadani.tablist.bukkit.utils.Util;
+import hu.montlikadani.tablist.bukkit.utils.reflection.ReflectionUtils;
+import hu.montlikadani.tablist.bukkit.utils.ServerVersion;
+
+public class RowPlayer implements IRowPlayer {
+
+	public final TabEntries root;
+	public final VariableReplacer replacer;
+
+	public int rowIndex = 0, columnIndex = 0;
+
+	private final TabList plugin = TabListAPI.getPlugin();
+	private final InfoName infoName;
+
+	private UUID skinId;
+	private String text = " ";
+	private Player player;
+
+	public RowPlayer(TabEntries root) {
+		this.root = root;
+
+		infoName = new InfoName(plugin);
+		replacer = new VariableReplacer(this);
+	}
+
+	public final InfoName getInfoName() {
+		return infoName;
+	}
+
+	@Override
+	public Optional<Player> asPlayer() {
+		return Optional.ofNullable(player);
+	}
+
+	@Override
+	public String getText() {
+		return text;
+	}
+
+	/**
+	 * Checks whenever this row text is empty
+	 * 
+	 * @return true if empty, otherwise false
+	 */
+	public final boolean isTextEmpty() {
+		return text.trim().isEmpty();
+	}
+
+	/**
+	 * Checks whenever the text is empty, skin is not set and another alive player
+	 * is not exist. More specifically, this row text is empty, skin uuid is not set
+	 * and player is also not set.
+	 * 
+	 * @return true if empty, otherwise false
+	 */
+	public final boolean isEmpty() {
+		return skinId == null && player == null && isTextEmpty();
+	}
+
+	@Override
+	public int getPingLatency() {
+		return infoName.getPing();
+	}
+
+	@Override
+	public void setText(String text) {
+		this.text = text == null ? " " : text;
+	}
+
+	@Override
+	public void setPing(int ping) {
+		infoName.setPing(ping);
+	}
+
+	@Override
+	public void setPlayer(Player player) {
+		if ((this.player = player) != null) {
+			infoName.movePlayer(player, rowIndex);
+		}
+	}
+
+	@Override
+	public UUID getHeadId() {
+		return skinId;
+	}
+
+	@Override
+	public void create(int rowIndex) {
+		if (player != null) {
+			return;
+		}
+
+		String name = String.format("%03d", this.rowIndex = rowIndex); // 00 + index - sort by row index
+		infoName.create(name, skinId, text);
+	}
+
+	public void show(Player player) {
+		if (plugin.getUsers().size() == 1 && infoName.getRowPlayer() != null && infoName.getPacket() != null) {
+			ReflectionUtils.sendPacket(player, infoName.getPacket());
+			ReflectionUtils.sendPacket(player, infoName.getRowPlayer());
+		} else {
+			infoName.addPlayer(null, text, player);
+		}
+	}
+
+	@Override
+	public void remove() {
+		infoName.remove(player);
+	}
+
+	@Override
+	// Thread-blocking method
+	public synchronized String updateText(Player player, String text) {
+		if (infoName.getRowPlayer() == null || player == null || this.player != null || text.trim().isEmpty()) {
+			// Player names should only be changed in groups
+			//
+			// Do not update empty entries too frequently
+			return text;
+		}
+
+		text = plugin.makeAnim(text);
+		text = replacer.replaceVariables(text);
+		text = plugin.getPlaceholders().replaceVariables(player, text);
+
+		if (ServerVersion.isCurrentLower(ServerVersion.v1_16_R1)) {
+			text = Util.colorMsg(text);
+		}
+
+		infoName.updateDisplayName(null, text, player);
+		return text;
+	}
+
+	@Override
+	public void setSkin(UUID skinId) {
+		if (player != null || skinId == null || skinId.equals(this.skinId)) {
+			return;
+		}
+
+		this.skinId = skinId;
+
+		if (Bukkit.getServer().getOnlineMode() && ServerVersion.isCurrentHigher(ServerVersion.v1_8_R2)) {
+			infoName.setSkin(text, skinId);
+		}
+	}
+}

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/AbstractVariable.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/AbstractVariable.java
@@ -1,0 +1,94 @@
+package hu.montlikadani.tablist.bukkit.tablist.entry.row.variable;
+
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.entity.Player;
+
+import hu.montlikadani.tablist.bukkit.TabList;
+import hu.montlikadani.tablist.bukkit.API.TabListAPI;
+import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabEntryValues.PlaceholderSetting;
+import hu.montlikadani.tablist.bukkit.tablist.entry.TabEntries.Entry;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.IRowPlayer;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.RowPlayer;
+import hu.montlikadani.tablist.bukkit.user.TabListUser;
+import hu.montlikadani.tablist.bukkit.utils.PluginUtils;
+
+public abstract class AbstractVariable {
+
+	protected final TabList plugin = TabListAPI.getPlugin();
+
+	protected final RowPlayer rowPlayer;
+	protected final String replacement;
+
+	public AbstractVariable(RowPlayer rowPlayer, String replacement) {
+		this.rowPlayer = rowPlayer;
+		this.replacement = replacement;
+	}
+
+	public String getReplacement() {
+		return replacement;
+	}
+
+	protected boolean canAddPlayer(Player player, PlaceholderSetting ps) {
+		if (player == null) {
+			return false;
+		}
+
+		Boolean parsed = ps.parseCondition(PlaceholderSetting.EntryCondition.ConditionType.IS_AFK);
+		if (parsed != null) {
+			return (parsed && PluginUtils.isAfk(player)) || (!parsed && !PluginUtils.isAfk(player));
+		}
+
+		parsed = ps.parseCondition(PlaceholderSetting.EntryCondition.ConditionType.IS_VANISHED);
+		if (parsed != null) {
+			return (parsed && PluginUtils.isVanished(player)) || (!parsed && !PluginUtils.isVanished(player));
+		}
+
+		return true;
+	}
+
+	protected String setText(String text, java.util.List<String> collectedNames, String replacement,
+			boolean isPlayers) {
+		if (collectedNames.isEmpty()) {
+			return StringUtils.replace(text, replacement, "");
+		}
+
+		Entry[][] entries = rowPlayer.root.getEntries();
+
+		boolean firstEqual = false;
+		int i = 0;
+		for (int rowIndex = 0; rowIndex < 20; rowIndex++) {
+			Entry entry = entries[rowPlayer.columnIndex][rowIndex];
+			if (entry != null) {
+				IRowPlayer r = entry.getRow();
+
+				if (isPlayers) {
+					if (!firstEqual && !(firstEqual = r.getText().equals(rowPlayer.getText()))) {
+						continue; // Dirty solution, to check the last row text is equal to the current row
+					}
+
+					if (i < collectedNames.size()) {
+						r.setPlayer(org.bukkit.Bukkit.getPlayer(collectedNames.get(i)));
+					}
+				} else {
+					if (i >= collectedNames.size()) {
+						break;
+					}
+
+					for (TabListUser user : plugin.getUsers()) {
+						r.updateText(user.getPlayer(), ((RowPlayer) r).replacer.setAndGetText(collectedNames.get(i)));
+					}
+
+					r.setPing(rowPlayer.getPingLatency());
+					r.setSkin(rowPlayer.getHeadId());
+				}
+			}
+
+			i++;
+		}
+
+		return StringUtils.replace(text, replacement, isPlayers ? "" : collectedNames.get(0));
+	}
+
+	public abstract String replace(String text);
+
+}

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/VariableReplacer.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/VariableReplacer.java
@@ -1,0 +1,50 @@
+package hu.montlikadani.tablist.bukkit.tablist.entry.row.variable;
+
+import com.google.common.collect.ImmutableSet;
+
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.RowPlayer;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.list.GroupPlayers;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.list.PlayersOnline;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.list.WorldPlayers;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.list.WorldsIndex;
+
+public final class VariableReplacer {
+
+	private String text = "";
+	private boolean updateRequest = true;
+
+	private final ImmutableSet<AbstractVariable> variables;
+
+	public VariableReplacer(RowPlayer rowPlayer) {
+		variables = ImmutableSet.<AbstractVariable>builder().add(new WorldsIndex(rowPlayer),
+				new PlayersOnline(rowPlayer), new WorldPlayers(rowPlayer), new GroupPlayers(rowPlayer)).build();
+	}
+
+	public String setAndGetText(String text) {
+		return this.text = text;
+	}
+
+	public boolean isUpdateRequested() {
+		return updateRequest;
+	}
+
+	public void requestUpdate() {
+		updateRequest = true;
+	}
+
+	public String replaceVariables(String text) {
+		if (!updateRequest) {
+			return this.text;
+		}
+
+		for (AbstractVariable variable : variables) {
+			String replaced = variable.replace(text);
+			if (replaced != null) {
+				updateRequest = false;
+				return this.text = replaced;
+			}
+		}
+
+		return this.text = text;
+	}
+}

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/list/GroupPlayers.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/list/GroupPlayers.java
@@ -1,0 +1,57 @@
+package hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.list;
+
+import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabEntryValues;
+import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabEntryValues.PlaceholderSetting;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.RowPlayer;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.AbstractVariable;
+import hu.montlikadani.tablist.bukkit.user.TabListUser;
+
+public final class GroupPlayers extends AbstractVariable {
+
+	public GroupPlayers(RowPlayer rowPlayer) {
+		super(rowPlayer, "%players_in_group_");
+	}
+
+	@Override
+	public String replace(String text) {
+		if (!plugin.hasVault()) {
+			return null;
+		}
+
+		int index = text.indexOf(replacement);
+		if (index < 0) {
+			return null;
+		}
+
+		PlaceholderSetting ps = TabEntryValues.VARIABLE_SETTINGS.get(PlaceholderSetting.SettingType.PLAYERS_IN_GROUP);
+		if (ps == null) {
+			return null;
+		}
+
+		// Retrieve group name from placeholder
+		String group = text.substring(index + replacement.length());
+		group = group.substring(0, group.lastIndexOf('%'));
+
+		java.util.List<String> playerNames = new java.util.ArrayList<>();
+
+		for (String name : plugin.getVaultPerm().getGroups()) {
+			if (group.equalsIgnoreCase(name)) {
+				for (TabListUser user : plugin.getUsers()) {
+					if (playerNames.size() >= ps.getMax()) {
+						break;
+					}
+
+					org.bukkit.entity.Player player = user.getPlayer();
+
+					if (player != null && plugin.getVaultPerm().playerInGroup(player, name) && canAddPlayer(player, ps)) {
+						playerNames.add(player.getName());
+					}
+				}
+
+				break;
+			}
+		}
+
+		return setText(text, playerNames, replacement + group + "%", true);
+	}
+}

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/list/PlayersOnline.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/list/PlayersOnline.java
@@ -1,0 +1,44 @@
+package hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.list;
+
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.entity.Player;
+
+import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabEntryValues;
+import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabEntryValues.PlaceholderSetting;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.RowPlayer;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.AbstractVariable;
+import hu.montlikadani.tablist.bukkit.user.TabListUser;
+
+public final class PlayersOnline extends AbstractVariable {
+
+	public PlayersOnline(RowPlayer rowPlayer) {
+		super(rowPlayer, "%players_online%");
+	}
+
+	@Override
+	public String replace(String text) {
+		if (!text.contains(replacement)) {
+			return null;
+		}
+
+		PlaceholderSetting ps = TabEntryValues.VARIABLE_SETTINGS.get(PlaceholderSetting.SettingType.ONLINE_PLAYERS);
+		if (ps == null) {
+			return StringUtils.replace(text, replacement, "");
+		}
+
+		java.util.List<String> collectedPlayerNames = new java.util.ArrayList<>();
+
+		for (TabListUser user : plugin.getUsers()) {
+			if (collectedPlayerNames.size() >= ps.getMax()) {
+				break;
+			}
+
+			Player player = user.getPlayer();
+			if (canAddPlayer(player, ps)) {
+				collectedPlayerNames.add(player.getName());
+			}
+		}
+
+		return setText(text, collectedPlayerNames, replacement, true);
+	}
+}

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/list/WorldPlayers.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/list/WorldPlayers.java
@@ -1,0 +1,64 @@
+package hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.list;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabEntryValues;
+import hu.montlikadani.tablist.bukkit.config.constantsLoader.TabEntryValues.PlaceholderSetting;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.RowPlayer;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.AbstractVariable;
+
+public final class WorldPlayers extends AbstractVariable {
+
+	public WorldPlayers(RowPlayer rowPlayer) {
+		super(rowPlayer, "%world_players_");
+	}
+
+	@Override
+	public String replace(String text) {
+		if (!text.contains(replacement)) {
+			return null;
+		}
+
+		List<World> worlds = plugin.getServer().getWorlds();
+
+		for (int w = 0; w < worlds.size(); w++) {
+			World world = worlds.get(w);
+			String replacement = this.replacement + world.getName() + "%";
+
+			if (!StringUtils.contains(text, replacement)) {
+				replacement = this.replacement + w + "%";
+			}
+
+			if (!StringUtils.contains(text, replacement)) {
+				continue;
+			}
+
+			PlaceholderSetting ps = TabEntryValues.VARIABLE_SETTINGS
+					.get(PlaceholderSetting.SettingType.WORLD_PLAYERS);
+			if (ps == null) {
+				return StringUtils.replace(text, replacement, "");
+			}
+
+			List<String> collectedPlayerNames = new ArrayList<>();
+
+			for (Player player : world.getPlayers()) {
+				if (collectedPlayerNames.size() >= ps.getMax()) {
+					break;
+				}
+
+				if (canAddPlayer(player, ps)) {
+					collectedPlayerNames.add(player.getName());
+				}
+			}
+
+			return setText(text, collectedPlayerNames, replacement, true);
+		}
+
+		return null;
+	}
+}

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/list/WorldsIndex.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/entry/row/variable/list/WorldsIndex.java
@@ -1,0 +1,33 @@
+package hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.list;
+
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.World;
+
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.RowPlayer;
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.variable.AbstractVariable;
+
+public final class WorldsIndex extends AbstractVariable {
+
+	public WorldsIndex(RowPlayer rowPlayer) {
+		super(rowPlayer, "%worlds_");
+	}
+
+	@Override
+	public String replace(String text) {
+		if (!text.contains(replacement)) {
+			return null;
+		}
+
+		List<World> worlds = plugin.getServer().getWorlds();
+
+		for (int i = 0; i < worlds.size(); i++) {
+			if (text.indexOf(replacement + i + "%") >= 0) {
+				return StringUtils.replace(text, replacement + i + "%", worlds.get(i).getName());
+			}
+		}
+
+		return null;
+	}
+}

--- a/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/fakeplayers/IFakePlayers.java
+++ b/bukkit/src/main/java/hu/montlikadani/tablist/bukkit/tablist/fakeplayers/IFakePlayers.java
@@ -1,13 +1,16 @@
 package hu.montlikadani.tablist.bukkit.tablist.fakeplayers;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.entity.Player;
 
+import hu.montlikadani.tablist.bukkit.tablist.entry.row.IRowPlayer;
+
 /**
  * The interface for creating fake players
  */
-public interface IFakePlayers {
+public interface IFakePlayers extends IRowPlayer {
 
 	/**
 	 * Gets the fake player name.
@@ -51,6 +54,7 @@ public interface IFakePlayers {
 	 * 
 	 * @return the amount of latency
 	 */
+	@Override
 	int getPingLatency();
 
 	/**
@@ -87,6 +91,7 @@ public interface IFakePlayers {
 	 * 
 	 * @param pingAmount ping value (> 0)
 	 */
+	@Override
 	void setPing(int pingAmount);
 
 	/**
@@ -95,6 +100,7 @@ public interface IFakePlayers {
 	 * 
 	 * @param skinId an valid user skin uuid
 	 */
+	@Override
 	void setSkin(UUID skinId);
 
 	/**
@@ -102,4 +108,43 @@ public interface IFakePlayers {
 	 */
 	void removeFakePlayer();
 
+	@Override
+	default void create(int rowIndex) {
+		throw new UnsupportedOperationException("Use #createFakePlayer instead");
+	}
+
+	@Override
+	default void remove() {
+		throw new UnsupportedOperationException("Use #removeFakePlayer instead");
+	}
+
+	@Override
+	default Optional<Player> asPlayer() {
+		throw new UnsupportedOperationException("#asPlayer not supported");
+	}
+
+	@Override
+	default void setPlayer(Player player) {
+		throw new UnsupportedOperationException("#setPlayer not supported");
+	}
+
+	@Override
+	default String getText() {
+		throw new UnsupportedOperationException("#getText not supported");
+	}
+
+	@Override
+	default String updateText(Player player, String text) {
+		throw new UnsupportedOperationException("#updateText not supported");
+	}
+
+	@Override
+	default void setText(String text) {
+		throw new UnsupportedOperationException("#setText not supported");
+	}
+
+	@Override
+	default UUID getHeadId() {
+		throw new UnsupportedOperationException("#getHeadId not supported");
+	}
 }


### PR DESCRIPTION
Old PR https://github.com/montlikadani/TabList/pull/151

Current issues/todos with this:
- In the specified entry, the player's name 42 (as a serial number) is displayed. This can be found in the `movePlayer` method.
  - No more player names displayed, just 1
- More placeholders needed
- Horizontal display with player names
- Player profiles may be lost upon modification, especially of skin data.
- Fake players are not considered, so they are "not visible" in the list when added.
- Ability to enter real player names to add skin for specific entry.

A smaller description of what it is:
This implementation is actually a list of fake (non-existent) player list columns that can be modified as desired. It is functional in the present state, but it is not complete, there are many shortcomings and few features yet. 